### PR TITLE
Add 'Move to...' and 'Copy to...' feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 A simple extension to duplicate a file or directory in VSCode.
 
+# Main features
+
+- Duplicate a file or directory
+- Move a file or directory to a new location
+- Copy a file or directory to a new location
+
 ## Demo
 
 ![Demo](https://raw.githubusercontent.com/trandaison/vscode-duplicate/main/demo.gif)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A vscode extension to duplicate files and folders",
   "publisher": "trandaison",
   "license": "MIT",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "engines": {
     "vscode": "^1.83.0",
     "node": "^18.16.0"
@@ -83,6 +83,14 @@
       {
         "command": "duplicate.execute",
         "title": "Duplicate"
+      },
+      {
+        "command": "duplicate.move",
+        "title": "Move to..."
+      },
+      {
+        "command": "duplicate.copy",
+        "title": "Copy to..."
       }
     ],
     "menus": {
@@ -90,6 +98,14 @@
         {
           "command": "duplicate.execute",
           "group": "7_modification"
+        },
+        {
+          "command": "duplicate.move",
+          "group": "5_cutcopypaste@40"
+        },
+        {
+          "command": "duplicate.copy",
+          "group": "5_cutcopypaste@41"
         }
       ],
       "editor/title/context": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,9 +6,9 @@ import { PluginSettings } from './types';
 export function activate(context: vscode.ExtensionContext) {
   console.log('vscode-duplicate is now active!');
 
-  let disposable = vscode.commands.registerCommand(
+  let disposableDuplicate = vscode.commands.registerCommand(
     'duplicate.execute',
-    (uri: vscode.TextDocument | vscode.Uri) => {
+    (uri) => {
       const settings = vscode.workspace
         .getConfiguration()
         .get('duplicate') as PluginSettings;
@@ -27,7 +27,45 @@ export function activate(context: vscode.ExtensionContext) {
     }
   );
 
-  context.subscriptions.push(disposable);
+  let disposableMove = vscode.commands.registerCommand(
+    'duplicate.move',
+    async (uri) => {
+      const folderUri = await vscode.window.showSaveDialog({
+        defaultUri: vscode.Uri.file(uri.fsPath),
+        saveLabel: 'Move to this folder',
+      });
+      if (!folderUri) {
+        return;
+      }
+      try {
+        await vscode.workspace.fs.rename(uri, folderUri, { overwrite: true });
+      } catch (error: any) {
+        vscode.window.showErrorMessage(error.message);
+      }
+    }
+  );
+
+  let disposableCopy = vscode.commands.registerCommand(
+    'duplicate.copy',
+    async (uri) => {
+      const folderUri = await vscode.window.showSaveDialog({
+        defaultUri: vscode.Uri.file(uri.fsPath),
+        saveLabel: 'Copy to this folder',
+      });
+      if (!folderUri) {
+        return;
+      }
+      try {
+        await vscode.workspace.fs.copy(uri, folderUri, { overwrite: true });
+      } catch (error: any) {
+        vscode.window.showErrorMessage(error.message);
+      }
+    }
+  );
+
+  context.subscriptions.push(disposableDuplicate);
+  context.subscriptions.push(disposableMove);
+  context.subscriptions.push(disposableCopy);
 }
 
 export function deactivate() {}


### PR DESCRIPTION
Related issue: https://github.com/trandaison/vscode-duplicate/issues/1

Add `Move to...` and `Copy to...` command to right context menu on explorer bar.

![Screenshot 2023-10-23 at 10 45 36](https://github.com/trandaison/vscode-duplicate/assets/13447235/a151b1f8-a1e2-4bf7-bb46-0cc44e9dfe7f)
